### PR TITLE
[BBB-76] 카카오 회원가입/로그인 Feign 응답 결과 매핑 DTO 수정

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/business/KakaoInfoProvider.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/business/KakaoInfoProvider.java
@@ -4,8 +4,8 @@ import static com.bangbangbwa.backend.domain.oauth.business.OAuthFeignManager.BE
 import static com.bangbangbwa.backend.domain.oauth.business.OAuthFeignManager.CONTENT_TYPE;
 import static com.bangbangbwa.backend.domain.oauth.business.OAuthFeignManager.GRANT_TYPE;
 
-import com.bangbangbwa.backend.domain.oauth.business.feign.KakaoTokenFeign;
 import com.bangbangbwa.backend.domain.oauth.business.feign.KakaoInfoFeign;
+import com.bangbangbwa.backend.domain.oauth.business.feign.KakaoTokenFeign;
 import com.bangbangbwa.backend.domain.oauth.common.dto.KakaoInfoDto;
 import com.bangbangbwa.backend.domain.oauth.common.dto.KakaoTokenDto;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,9 +39,9 @@ public class KakaoInfoProvider {
     return kakaoInfoFeign.requestInfo(BEARER + accessToken, CONTENT_TYPE);
   }
 
-  public KakaoTokenDto getInfoByCode(String oauthToken) {
+  public KakaoTokenDto getInfoByCode(String authCode) {
     return kakaoTokenFeign.getAccessToken(
-        oauthToken,
+        authCode,
         KAKAO_CLIENT_ID,
         KAKAO_CLIENT_SECRET,
         KAKAO_REDIRECT_URI,

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/business/OAuthFeignManager.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/business/OAuthFeignManager.java
@@ -39,7 +39,7 @@ public class OAuthFeignManager {
   public OAuthInfoDto getKakaoInfo(String accessToken) throws FeignException {
     KakaoInfoDto kakaoInfoDto = kakaoInfoProvider.getInfo(accessToken);
     return OAuthInfoDto.builder()
-        .email(kakaoInfoDto.email())
+        .email(kakaoInfoDto.kakaoAccount().email())
         .snsId(kakaoInfoDto.id())
         .snsType(SnsType.KAKAO)
         .oAuthToken(accessToken)
@@ -71,7 +71,7 @@ public class OAuthFeignManager {
     KakaoTokenDto kakaoTokenDto = kakaoInfoProvider.getInfoByCode(authCode);
     KakaoInfoDto kakaoInfoDto = kakaoInfoProvider.getInfo(kakaoTokenDto.accessToken());
     return OAuthInfoDto.builder()
-        .email(kakaoInfoDto.email())
+        .email(kakaoInfoDto.kakaoAccount().email())
         .snsId(kakaoInfoDto.id())
         .snsType(SnsType.KAKAO)
         .oAuthToken(kakaoTokenDto.accessToken())

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/business/feign/NaverTokenFeign.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/business/feign/NaverTokenFeign.java
@@ -1,6 +1,5 @@
 package com.bangbangbwa.backend.domain.oauth.business.feign;
 
-import com.bangbangbwa.backend.domain.oauth.common.dto.GoogleTokenDto;
 import com.bangbangbwa.backend.domain.oauth.common.dto.NaverTokenDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoAccount.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoAccount.java
@@ -1,0 +1,7 @@
+package com.bangbangbwa.backend.domain.oauth.common.dto;
+
+public record KakaoAccount(
+    String email
+) {
+
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoInfoDto.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoInfoDto.java
@@ -1,8 +1,12 @@
 package com.bangbangbwa.backend.domain.oauth.common.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoInfoDto(
     String id,
-    String email
+    KakaoAccount kakaoAccount
 ) {
 
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoTokenDto.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/KakaoTokenDto.java
@@ -1,12 +1,10 @@
 package com.bangbangbwa.backend.domain.oauth.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoTokenDto(
-    @JsonProperty("access_token")
     String accessToken
 ) {
 

--- a/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/NaverInfoDto.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/oauth/common/dto/NaverInfoDto.java
@@ -13,5 +13,7 @@ public record NaverInfoDto(String resultcode, String message, Response response)
       String birthday,
       String birthyear,
       String mobile
-  ) {}
+  ) {
+
+  }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 카카오 회원가입/로그인 관련 Feign 응답 결과 매핑 DTO 수정
  - [공식문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info) 참조

## 🔖 반영 브랜치
- feature/BBB-76-> develop

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- Naver 회원가입/로그인 수정

## ➕ 이슈 링크

- https://bangbangbwa.atlassian.net/browse/BBB-76
