### PR TITLE
[BBB-84] 게시물 상세 조회 존재하지 않는 게시물일 경우 예외 처리

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
@@ -21,7 +21,7 @@ public class PostReader {
   }
 
   public GetPostDetailsDto.Response getPostDetails(Long postId, Long memberId) {
-    return postRepository.getPostDetails(postId, memberId);
+    return postRepository.getPostDetails(postId, memberId).orElseThrow(NotFoundPostException::new);
   }
 
   public List<Post> findAllByPostType(PostType postType) {

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
@@ -32,10 +32,10 @@ public class PostRepository {
     return mysql.selectList("PostMapper.findPostsWithinLast24Hours", postType);
   }
 
-  public GetPostDetailsDto.Response getPostDetails(Long postId, Long memberId) {
+  public Optional<GetPostDetailsDto.Response> getPostDetails(Long postId, Long memberId) {
     Map<String, Object> params = new HashMap<>();
     params.put("postId", postId);
     params.put("memberId", memberId);
-    return mysql.selectOne("PostMapper.getPostDetails", params);
+    return Optional.ofNullable(mysql.selectOne("PostMapper.getPostDetails", params));
   }
 }

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
@@ -16,6 +16,7 @@ import com.bangbangbwa.backend.domain.sns.common.dto.*;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
 import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
 import com.bangbangbwa.backend.domain.sns.exception.InvalidMemberVisibilityException;
+import com.bangbangbwa.backend.domain.sns.exception.NotFoundPostException;
 import com.bangbangbwa.backend.domain.sns.repository.PostRepository;
 import com.bangbangbwa.backend.domain.token.business.TokenProvider;
 import com.bangbangbwa.backend.domain.token.common.TokenDto;
@@ -157,6 +158,32 @@ class SnsIntegrationTest extends IntegrationTest {
 //    assertThat(apiResponse.getData().comment()).isEqualTo();
 
   }
+
+  @Test
+  void getPostDetails_존재하지_않는_게시물() {
+    // given
+    Long postId = RandomValue.getRandomLong(-999,-1);
+
+    String url = "http://localhost:" + port + "/api/v1/sns/getPostDetails/" + postId;
+
+    NotFoundPostException exception = new NotFoundPostException();
+
+    // when
+    ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
+
+    ApiResponse<GetPostDetailsDto.Response> apiResponse = gson.fromJson(
+            responseEntity.getBody(),
+            new TypeToken<ApiResponse<GetPostDetailsDto.Response>>() {}.getType()
+    );
+
+    // then
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertNull(apiResponse.getData());
+    assertThat(apiResponse.getCode()).isEqualTo(exception.getCode());
+    assertThat(apiResponse.getMessage()).isEqualTo(exception.getMessage());
+
+  }
+
 
 
   // note. PostType 랜덤 지정하도록 변경 필요


### PR DESCRIPTION
## 🔎 작업 내용

- 게시물 상세 조회 존재하지 않는 게시물일 경우 예외 처리

## 🔖 반영 브랜치
- feature/BBB-84 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- 스트리머 승인 대기 중 사용자 재신청 불가능하도록 변경

## ➕ 이슈 링크

- 
https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-84