### PR TITLE
[BBB-65] 방송 계정 승인 대기 중 사용자 재신청 불가능하도록 변경

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PromoteValidator.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PromoteValidator.java
@@ -1,0 +1,21 @@
+package com.bangbangbwa.backend.domain.sns.business;
+
+import com.bangbangbwa.backend.domain.sns.exception.DuplicatePendingPromotionException;
+import com.bangbangbwa.backend.domain.streamer.common.enums.PendingType;
+import com.bangbangbwa.backend.domain.streamer.repository.PendingStreamerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PromoteValidator {
+
+    private final PendingStreamerRepository pendingStreamerRepository;
+
+    public void checkForDuplicatePendingPromotion(Long memberId) {
+        pendingStreamerRepository.findByMemberIdAndStatus(memberId, PendingType.PENDING)
+                .ifPresent(pendingPromotion -> {
+                    throw new DuplicatePendingPromotionException();
+                });
+    }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/exception/DuplicatePendingPromotionException.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/exception/DuplicatePendingPromotionException.java
@@ -1,0 +1,20 @@
+package com.bangbangbwa.backend.domain.sns.exception;
+
+import com.bangbangbwa.backend.domain.sns.exception.type.PostErrorType;
+import com.bangbangbwa.backend.global.error.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class DuplicatePendingPromotionException extends BusinessException {
+
+  private final String code;
+
+  public DuplicatePendingPromotionException() {
+    this(PostErrorType.DUPLICATE_PENDING_PROMOTION.getMessage());
+  }
+
+  public DuplicatePendingPromotionException(String message) {
+    super(message);
+    this.code = PostErrorType.DUPLICATE_PENDING_PROMOTION.name();
+  }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/exception/type/PostErrorType.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/exception/type/PostErrorType.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum PostErrorType {
   NO_POST_PERMISSION("작성 권한이 없습니다."),
   NOT_FOUND_POST("존재하지 않는 게시물 입니다."),
-  INVALID_MEMBER_VISIBILITY("공개/비공개 값은 함께 전달할 수 없습니다.");
+  INVALID_MEMBER_VISIBILITY("공개/비공개 값은 함께 전달할 수 없습니다."),
+
+  DUPLICATE_PENDING_PROMOTION("승인 대기 중인 신청이 이미 존재합니다.");
 
 
   private final String message;

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/PendingStreamerGenerator.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/PendingStreamerGenerator.java
@@ -3,7 +3,6 @@ package com.bangbangbwa.backend.domain.streamer.common.business;
 import com.bangbangbwa.backend.domain.admin.common.dto.ApproveStreamerDto;
 import com.bangbangbwa.backend.domain.admin.common.entity.Admin;
 import com.bangbangbwa.backend.domain.member.common.dto.PromoteStreamerDto;
-import com.bangbangbwa.backend.domain.member.common.entity.Member;
 import com.bangbangbwa.backend.domain.streamer.common.entity.PendingStreamer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,9 +13,9 @@ public class PendingStreamerGenerator {
 
   private final PendingStreamerParser pendingStreamerParser;
 
-  public PendingStreamer generate(PromoteStreamerDto.Request request, Member member) {
+  public PendingStreamer generate(PromoteStreamerDto.Request request, Long memberId) {
     PendingStreamer pendingStreamer = pendingStreamerParser.requestToEntity(request);
-    pendingStreamer.updateMemberId(member.getId());
+    pendingStreamer.updateMemberId(memberId);
     return pendingStreamer;
   }
 

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/repository/PendingStreamerRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/repository/PendingStreamerRepository.java
@@ -1,9 +1,14 @@
 package com.bangbangbwa.backend.domain.streamer.repository;
 
 import com.bangbangbwa.backend.domain.streamer.common.entity.PendingStreamer;
+import com.bangbangbwa.backend.domain.streamer.common.enums.PendingType;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,5 +22,12 @@ public class PendingStreamerRepository {
 
   public void updateStatus(PendingStreamer pendingStreamer) {
     mysql.insert("PendingStreamerMapper.updateStatus",pendingStreamer);
+  }
+
+  public Optional<PendingStreamer> findByMemberIdAndStatus(Long memberId, PendingType status) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("memberId", memberId);
+    params.put("status", status);
+    return Optional.ofNullable(mysql.selectOne("PendingStreamerMapper.findByMemberIdAndStatus", params));
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/service/PendingStreamerService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/service/PendingStreamerService.java
@@ -2,7 +2,7 @@ package com.bangbangbwa.backend.domain.streamer.service;
 
 import com.bangbangbwa.backend.domain.member.business.MemberProvider;
 import com.bangbangbwa.backend.domain.member.common.dto.PromoteStreamerDto;
-import com.bangbangbwa.backend.domain.member.common.entity.Member;
+import com.bangbangbwa.backend.domain.sns.business.PromoteValidator;
 import com.bangbangbwa.backend.domain.streamer.common.business.PendingStreamerCreator;
 import com.bangbangbwa.backend.domain.streamer.common.business.PendingStreamerGenerator;
 import com.bangbangbwa.backend.domain.streamer.common.entity.PendingStreamer;
@@ -16,10 +16,12 @@ public class PendingStreamerService {
   private final MemberProvider memberProvider;
   private final PendingStreamerGenerator pendingStreamerGenerator;
   private final PendingStreamerCreator pendingStreamerCreator;
+  private final PromoteValidator promoteValidator;
 
   public PendingStreamer promoteStreamer(PromoteStreamerDto.Request request) {
-    Member member = memberProvider.getCurrentMember();
-    PendingStreamer pendingStreamer = pendingStreamerGenerator.generate(request, member);
+    Long memberId = memberProvider.getCurrentMemberId();
+    promoteValidator.checkForDuplicatePendingPromotion(memberId);
+    PendingStreamer pendingStreamer = pendingStreamerGenerator.generate(request, memberId);
     pendingStreamerCreator.save(pendingStreamer);
     return pendingStreamer;
   }

--- a/src/main/resources/mybatis/map/pendingStreamer.xml
+++ b/src/main/resources/mybatis/map/pendingStreamer.xml
@@ -19,6 +19,9 @@
     WHERE id = #{id}
   </update>
 
+  <select id="findByMemberIdAndStatus" parameterType="map" resultType="PendingStreamer">
+    SELECT * FROM pending_streamer WHERE member_id = #{memberId} AND status = #{status}
+  </select>
 
 
 </mapper>

--- a/src/test/java/com/bangbangbwa/backend/domain/member/MemberTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/member/MemberTest.java
@@ -1,0 +1,177 @@
+package com.bangbangbwa.backend.domain.member;
+
+import com.bangbangbwa.backend.domain.member.common.dto.PromoteStreamerDto;
+import com.bangbangbwa.backend.domain.member.common.entity.Member;
+import com.bangbangbwa.backend.domain.member.exception.UnAuthenticationMemberException;
+import com.bangbangbwa.backend.domain.member.repository.MemberRepository;
+import com.bangbangbwa.backend.domain.oauth.common.dto.OAuthInfoDto;
+import com.bangbangbwa.backend.domain.oauth.common.enums.SnsType;
+import com.bangbangbwa.backend.domain.sns.exception.DuplicatePendingPromotionException;
+import com.bangbangbwa.backend.domain.streamer.common.entity.PendingStreamer;
+import com.bangbangbwa.backend.domain.streamer.repository.PendingStreamerRepository;
+import com.bangbangbwa.backend.domain.token.business.TokenProvider;
+import com.bangbangbwa.backend.domain.token.common.TokenDto;
+import com.bangbangbwa.backend.global.response.ApiResponse;
+import com.bangbangbwa.backend.global.test.IntegrationTest;
+import com.bangbangbwa.backend.global.util.randomValue.RandomValue;
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class MemberTest extends IntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PendingStreamerRepository pendingStreamerRepository;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    private Member getMember() {
+        Member member = Member.builder()
+                .nickname(RandomValue.string(255).setNullable(false).get())
+                .build();
+        OAuthInfoDto oAuthInfo = OAuthInfoDto.builder()
+                .snsId(RandomValue.string(255).setNullable(false).get())
+                .email(RandomValue.string(255).setNullable(false).getEmail())
+                .snsType(RandomValue.getRandomEnum(SnsType.class))
+                .build();
+        member.addOAuthInfo(oAuthInfo);
+        member.updateProfile(RandomValue.string(255).get());
+
+        return member;
+    }
+
+    private Member createMember() {
+        Member member = getMember();
+        memberRepository.save(member);
+        return member;
+    }
+
+    private PendingStreamer getPendingStreamer(Member member) {
+        return PendingStreamer.builder()
+                .memberId(member.getId())
+                .platformUrl(RandomValue.string(255).setNullable(false).get())
+                .build();
+    }
+
+    private PendingStreamer createPendingStreamer(Member member) {
+        PendingStreamer pendingStreamer = getPendingStreamer(member);
+        pendingStreamerRepository.save(pendingStreamer);
+        return pendingStreamer;
+    }
+
+
+
+    @Test
+    void promoteStreamer() {
+        // given
+        Member member = createMember();
+        TokenDto tokenDto = tokenProvider.getToken(member);
+
+        String profileUrl = RandomValue.string(255).setNullable(false).get();
+        PromoteStreamerDto.Request request = new PromoteStreamerDto.Request(profileUrl);
+
+        String url = "http://localhost:" + port + "/api/v1/members/promoteStreamer";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenDto.getAccessToken());
+        HttpEntity<PromoteStreamerDto.Request> requestEntity = new HttpEntity<>(request, headers);
+
+        // when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(
+                url,
+                requestEntity,
+                String.class
+        );
+
+        ApiResponse<PromoteStreamerDto.Response> apiResponse = gson.fromJson(
+                responseEntity.getBody(),
+                new TypeToken<ApiResponse<PromoteStreamerDto.Response>>() {}.getType()
+        );
+        // then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(apiResponse.getData()).isNotNull();
+        assertThat(apiResponse.getData().platformUrl()).isEqualTo(profileUrl);
+    }
+
+    @Test
+    void promoteStreamer_토큰_미입력() {
+        // given
+        String profileUrl = RandomValue.string(255).setNullable(false).get();
+        PromoteStreamerDto.Request request = new PromoteStreamerDto.Request(profileUrl);
+
+        String url = "http://localhost:" + port + "/api/v1/members/promoteStreamer";
+
+        UnAuthenticationMemberException exception = new UnAuthenticationMemberException();
+
+        // when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(
+                url,
+                request,
+                String.class
+        );
+
+        ApiResponse<PromoteStreamerDto.Response> apiResponse = gson.fromJson(
+                responseEntity.getBody(),
+                new TypeToken<ApiResponse<PromoteStreamerDto.Response>>() {}.getType()
+        );
+        // then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(apiResponse.getData()).isNull();
+        assertThat(apiResponse.getCode()).isEqualTo(exception.getCode());
+        assertThat(apiResponse.getMessage()).isEqualTo(exception.getMessage());
+    }
+
+    @Test
+    void promoteStreamer_중복_요청() {
+        // given
+        Member member = createMember();
+        createPendingStreamer(member);
+        TokenDto tokenDto = tokenProvider.getToken(member);
+
+        String profileUrl = RandomValue.string(255).setNullable(false).get();
+        PromoteStreamerDto.Request request = new PromoteStreamerDto.Request(profileUrl);
+
+        String url = "http://localhost:" + port + "/api/v1/members/promoteStreamer";
+
+        DuplicatePendingPromotionException exception = new DuplicatePendingPromotionException();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenDto.getAccessToken());
+        HttpEntity<PromoteStreamerDto.Request> requestEntity = new HttpEntity<>(request, headers);
+
+        // when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(
+                url,
+                requestEntity,
+                String.class
+        );
+
+        ApiResponse<PromoteStreamerDto.Response> apiResponse = gson.fromJson(
+                responseEntity.getBody(),
+                new TypeToken<ApiResponse<PromoteStreamerDto.Response>>() {}.getType()
+        );
+        // then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(apiResponse.getData()).isNull();
+        assertThat(apiResponse.getCode()).isEqualTo(exception.getCode());
+        assertThat(apiResponse.getMessage()).isEqualTo(exception.getMessage());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 방송 계정 승인 대기 중 사용자 재신청 불가능하도록 변경

## 🔖 반영 브랜치
- feature/BBB-65 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- 등업 요청 관리 테스트 코트 작성 및 리펙토링

## ➕ 이슈 링크

- https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-65
