### PR TITLE
[BBB-85] 방송인 최신 글 표시 팔로우 관련 작업

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
@@ -7,6 +7,8 @@ import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
 import com.bangbangbwa.backend.domain.sns.exception.NotFoundPostException;
 import com.bangbangbwa.backend.domain.sns.repository.PostRepository;
 import java.util.List;
+import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +30,7 @@ public class PostReader {
     return postRepository.findAllByPostType(postType);
   }
 
-  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType) {
-    return postRepository.findPostsWithinLast24Hours(postType);
+  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType, Set<String> readerPostList) {
+    return postRepository.findPostsWithinLast24Hours(postType, readerPostList);
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/ReaderPostCreator.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/ReaderPostCreator.java
@@ -1,0 +1,16 @@
+package com.bangbangbwa.backend.domain.sns.business;
+
+import com.bangbangbwa.backend.domain.sns.repository.ReaderPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReaderPostCreator {
+
+    private final ReaderPostRepository readerPostRepository;
+
+    public void addReadPost (Long memberId, Long postId) {
+        readerPostRepository.addReadPost(memberId.toString(), postId.toString());
+    }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/ReaderPostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/ReaderPostReader.java
@@ -1,0 +1,17 @@
+package com.bangbangbwa.backend.domain.sns.business;
+
+import com.bangbangbwa.backend.domain.sns.repository.ReaderPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ReaderPostReader {
+
+    private final ReaderPostRepository readerPostRepository;
+
+    public Set<String> findAllReadPostsByMemberId(Long memberId) {
+        return readerPostRepository.findAllReadPostsByMemberId(memberId.toString());
+    }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/common/dto/GetLatestPostsDto.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/common/dto/GetLatestPostsDto.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GetLatestPostsDto {
 
-  @Schema(description = "방송인ID")
-  Long streamerId;
+  @Schema(description = "멤버ID")
+  Long memberId;
   @Schema(description = "프로필 사진")
   String profileUrl;
   @Schema(description = "최근 게시물")
@@ -21,7 +21,7 @@ public class GetLatestPostsDto {
 
   public Response toResponse(DailyMessage dailyMessage) {
     return new Response(
-        this.streamerId,
+        this.memberId,
         this.profileUrl,
         dailyMessage.getMessage(),
         convertPostIdsToList(this.postIdList)
@@ -37,8 +37,8 @@ public class GetLatestPostsDto {
 
   @Schema(name = "GetLatestPostsDto_Response", description = "사용자 최신글 조회 반환")
   public record Response(
-      @Schema(description = "방송인ID")
-      Long streamerId,
+      @Schema(description = "멤버ID")
+      Long memberId,
       @Schema(description = "프로필 사진")
       String profileUrl,
       @Schema(description = "오늘의 한마디")

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
@@ -95,7 +95,7 @@ public class SnsController implements SnsApi{
   }
 
   @GetMapping("/getLatestPosts")
-  @AuthenticationContext
+  @PreAuthorize("permitAll()")
   public ApiResponse<List<GetLatestPostsDto.Response>> getLatestPosts() {
     List<GetLatestPostsDto> getLatestPostsDto = snsService.getLatestPosts(PostType.STREAMER);
 

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
@@ -97,18 +97,7 @@ public class SnsController implements SnsApi{
   @GetMapping("/getLatestPosts")
   @PreAuthorize("permitAll()")
   public ApiResponse<List<GetLatestPostsDto.Response>> getLatestPosts() {
-    List<GetLatestPostsDto> getLatestPostsDto = snsService.getLatestPosts(PostType.STREAMER);
-
-    List<Long> streamerIds = getLatestPostsDto.stream()
-        .map(GetLatestPostsDto::getStreamerId)
-        .collect(Collectors.toList());
-
-    List<DailyMessage> dailyMessageList = dailyMessageService.getDailyMessagesByIds(streamerIds);
-
-    List<GetLatestPostsDto.Response> response = IntStream.range(0, getLatestPostsDto.size())
-        .mapToObj(i -> getLatestPostsDto.get(i).toResponse(dailyMessageList.get(i)))
-        .collect(Collectors.toList());
-
+    List<GetLatestPostsDto.Response> response = snsService.getLatestPosts(PostType.STREAMER);
     return ApiResponse.ok(response);
   }
 

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
@@ -9,14 +9,10 @@ import com.bangbangbwa.backend.domain.sns.common.mapper.CommentMapper;
 import com.bangbangbwa.backend.domain.sns.common.mapper.PostMapper;
 import com.bangbangbwa.backend.domain.sns.service.SnsService;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
-import com.bangbangbwa.backend.domain.streamer.common.entity.DailyMessage;
-import com.bangbangbwa.backend.domain.streamer.service.DailyMessageService;
 import com.bangbangbwa.backend.global.annotation.authentication.AuthenticationContext;
 import com.bangbangbwa.backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -35,7 +31,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class SnsController implements SnsApi{
 
   private final SnsService snsService;
-  private final DailyMessageService dailyMessageService;
 
   @GetMapping("/getPostList")
   @AuthenticationContext

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
@@ -4,10 +4,9 @@ import com.bangbangbwa.backend.domain.sns.common.dto.GetLatestPostsDto;
 import com.bangbangbwa.backend.domain.sns.common.dto.GetPostDetailsDto;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
 import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.stereotype.Repository;
@@ -28,8 +27,11 @@ public class PostRepository {
     return mysql.selectList("PostMapper.findAllByPostType", postType);
   }
 
-  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType) {
-    return mysql.selectList("PostMapper.findPostsWithinLast24Hours", postType);
+  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType, Set<String> readerPostList) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("postType", postType);
+    params.put("readerPostList", readerPostList);
+    return mysql.selectList("PostMapper.findPostsWithinLast24Hours", params);
   }
 
   public Optional<GetPostDetailsDto.Response> getPostDetails(Long postId, Long memberId) {

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepository.java
@@ -1,0 +1,32 @@
+package com.bangbangbwa.backend.domain.sns.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class ReaderPostRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public ReaderPostRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public static final String PREFIX = "read_post:";
+    private static final TimeUnit EXPIRATION_UNIT = TimeUnit.HOURS;
+    private static final long EXPIRATION_TIME = 30;
+
+    public void addReadPost(String memberId, String postId) {
+        String key = PREFIX + memberId;
+        redisTemplate.opsForSet().add(key, postId);
+        redisTemplate.expire(key, EXPIRATION_TIME, EXPIRATION_UNIT);
+    }
+
+    public Set<String> findAllReadPostsByMemberId(String memberId) {
+        String key = PREFIX + memberId;
+        return redisTemplate.opsForSet().members(key);
+    }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
@@ -102,6 +102,18 @@ public class SnsService {
 
   public List<GetLatestPostsDto> getLatestPosts(PostType postType) {
     return postReader.findPostsWithinLast24Hours(postType);
+  public List<GetLatestPostsDto.Response> getLatestPosts(PostType postType) {
+    Set<String> readerPostList = new HashSet<>();
+    List<GetLatestPostsDto> getLatestPostsDto = postReader.findPostsWithinLast24Hours(postType, readerPostList);
+    List<Long> memberIds = getLatestPostsDto.stream()
+            .map(GetLatestPostsDto::getMemberId)
+            .toList();
+
+    List<DailyMessage> dailyMessageList = dailyMessageReader.findByIds(memberIds);
+
+      return IntStream.range(0, getLatestPostsDto.size())
+              .mapToObj(i -> getLatestPostsDto.get(i).toResponse(dailyMessageList.get(i)))
+              .collect(Collectors.toList());
   }
 
   public void reportPost(ReportPostDto.Request request) {

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/DailyMessageCreator.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/DailyMessageCreator.java
@@ -13,7 +13,7 @@ public class DailyMessageCreator {
 
   public void save(DailyMessage dailyMessage) {
     dailyMessageRepository.save(
-        dailyMessage.getStreamerId(),
+        dailyMessage.getMemberId(),
         dailyMessage.getMessage(),
         dailyMessage.getExpirationTime()
     );

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/DailyMessageGenerator.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/common/business/DailyMessageGenerator.java
@@ -1,6 +1,5 @@
 package com.bangbangbwa.backend.domain.streamer.common.business;
 
-import com.bangbangbwa.backend.domain.promotion.common.entity.Streamer;
 import com.bangbangbwa.backend.domain.streamer.common.dto.CreateDailyMessageDto;
 import com.bangbangbwa.backend.domain.streamer.common.entity.DailyMessage;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +11,9 @@ public class DailyMessageGenerator {
 
   private final DailyMessageParser dailyMessageParser;
 
-  public DailyMessage generate(CreateDailyMessageDto.Request request, Streamer streamer) {
+  public DailyMessage generate(CreateDailyMessageDto.Request request, Long memberId) {
     DailyMessage dailyMessage = dailyMessageParser.requestToEntity(request);
-    dailyMessage.updateStreamerId(streamer.getId());
+    dailyMessage.updateMemberId(memberId);
     return dailyMessage;
   }
 

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/common/entity/DailyMessage.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/common/entity/DailyMessage.java
@@ -10,18 +10,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DailyMessage {
 
-  private Long streamerId;
+  private Long memberId;
   private String message;
   private Long expirationTime;
 
   @Builder
-  public DailyMessage(Long streamerId, String message) {
-    this.streamerId = streamerId;
+  public DailyMessage(Long memberId, String message) {
+    this.memberId = memberId;
     this.message = message;
     this.expirationTime = 24L;
   }
 
-  public void updateStreamerId(Long streamerId) {
-    this.streamerId = streamerId;
+  public void updateMemberId(Long streamerId) {
+    this.memberId = streamerId;
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/repository/DailyMessageRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/repository/DailyMessageRepository.java
@@ -38,14 +38,14 @@ public class DailyMessageRepository {
 
     return IntStream.range(0, ids.size())
         .mapToObj(i -> DailyMessage.builder()
-            .streamerId(ids.get(i))
+            .memberId(ids.get(i))
             .message(messages != null ? messages.get(i) : null)
             .build())
         .collect(Collectors.toList());
   }
 
-  public String getDailyMessage(Long streamerId) {
-    String key = PREFIX + streamerId;
+  public String getDailyMessage(Long memberId) {
+    String key = PREFIX + memberId;
     return redisTemplate.opsForValue().get(key);
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/streamer/service/DailyMessageService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/streamer/service/DailyMessageService.java
@@ -1,7 +1,6 @@
 package com.bangbangbwa.backend.domain.streamer.service;
 
 import com.bangbangbwa.backend.domain.member.business.MemberProvider;
-import com.bangbangbwa.backend.domain.promotion.common.entity.Streamer;
 import com.bangbangbwa.backend.domain.streamer.common.business.DailyMessageCreator;
 import com.bangbangbwa.backend.domain.streamer.common.business.DailyMessageGenerator;
 import com.bangbangbwa.backend.domain.streamer.common.business.DailyMessageReader;
@@ -21,8 +20,8 @@ public class DailyMessageService {
   private final DailyMessageReader dailyMessageReader;
 
   public DailyMessage createDailyMessage(CreateDailyMessageDto.Request request) {
-    Streamer streamer = memberProvider.getCurrentStreamer();
-    DailyMessage dailyMessage = dailyMessageGenerator.generate(request, streamer);
+    Long memberId = memberProvider.getCurrentMemberId();
+    DailyMessage dailyMessage = dailyMessageGenerator.generate(request, memberId);
     dailyMessageCreator.save(dailyMessage);
     return dailyMessage;
   }

--- a/src/main/resources/mybatis/map/post.xml
+++ b/src/main/resources/mybatis/map/post.xml
@@ -38,6 +38,9 @@
     WHERE
     p.created_at >= NOW() - INTERVAL '1' DAY
     AND p.post_type = #{postType}
+    <foreach item="postId" collection="readerPostList" open="AND p.id NOT IN (" close=")" separator=",">
+      #{postId}
+    </foreach>
     GROUP BY
     s.id, m.profile
     ORDER BY

--- a/src/main/resources/mybatis/map/post.xml
+++ b/src/main/resources/mybatis/map/post.xml
@@ -19,22 +19,20 @@
 
 
   <resultMap id="GetLatestPostsDtoMap" type="com.bangbangbwa.backend.domain.sns.common.dto.GetLatestPostsDto">
-    <result property="streamerId" column="streamerId" />
+    <result property="memberId" column="memberId" />
     <result property="profileUrl" column="profileUrl" />
     <result property="postIdList" column="postIdList" />
   </resultMap>
 
   <select id="findPostsWithinLast24Hours" parameterType="PostType" resultMap="GetLatestPostsDtoMap">
     SELECT
-    s.id AS streamerId,
+    m.id AS memberId,
     m.profile AS profileUrl,
     GROUP_CONCAT(p.id ORDER BY p.created_at DESC) AS postIdList
     FROM
     posts p
     JOIN
     members m ON p.member_id = m.id
-    LEFT JOIN
-    streamers s ON m.id = s.member_id
     WHERE
     p.created_at >= NOW() - INTERVAL '1' DAY
     AND p.post_type = #{postType}
@@ -42,7 +40,7 @@
       #{postId}
     </foreach>
     GROUP BY
-    s.id, m.profile
+    m.id, m.profile
     ORDER BY
     MAX(p.created_at) DESC;
   </select>

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.bangbangbwa.backend.domain.sns.repository;
+
+import com.bangbangbwa.backend.domain.member.common.entity.Member;
+import com.bangbangbwa.backend.domain.member.repository.MemberRepository;
+import com.bangbangbwa.backend.domain.oauth.common.dto.OAuthInfoDto;
+import com.bangbangbwa.backend.domain.oauth.common.enums.SnsType;
+import com.bangbangbwa.backend.domain.sns.common.dto.GetLatestPostsDto;
+import com.bangbangbwa.backend.domain.sns.common.entity.Post;
+import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
+import com.bangbangbwa.backend.global.test.MyBatisTest;
+import com.bangbangbwa.backend.global.util.randomValue.RandomValue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import({PostRepository.class, MemberRepository.class})
+class PostRepositoryTest extends MyBatisTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    private Member getMember() {
+        Member member = Member.builder()
+                .nickname(RandomValue.string(255).setNullable(false).get())
+                .build();
+        OAuthInfoDto oAuthInfo = OAuthInfoDto.builder()
+                .snsId(RandomValue.string(255).setNullable(false).get())
+                .email(RandomValue.string(255).setNullable(false).getEmail())
+                .snsType(RandomValue.getRandomEnum(SnsType.class))
+                .build();
+        member.addOAuthInfo(oAuthInfo);
+        member.updateProfile(RandomValue.string(255).get());
+
+        return member;
+    }
+
+    private Member createMember() {
+        Member member = getMember();
+        memberRepository.save(member);
+        return member;
+    }
+
+    private Post getPost(PostType postType, Member member) {
+        return Post.builder()
+                .postType(postType)
+                .memberId(member.getId())
+                .title(RandomValue.string(100).setNullable(false).get())
+                .content(RandomValue.string(2000).setNullable(false).get())
+                .build();
+    }
+
+    private Post createPost(PostType postType, Member writeMember) {
+        Post post = getPost(postType, writeMember);
+        postRepository.save(post);
+        return post;
+    }
+
+    @Test()
+    void findPostsWithinLast24Hours() {
+        // given
+        Member writeMember = createMember();
+        PostType postType = RandomValue.getRandomEnum(PostType.class);
+
+        int readPostCount = RandomValue.getInt(0, 5);
+        int newPostCount = RandomValue.getInt(0, 5);
+
+        Set<String> readerPostList = IntStream.range(0, readPostCount)
+                .mapToObj(i -> createPost(postType, writeMember).getId().toString())
+                .collect(Collectors.toSet());
+
+        List<Long> newPostList = IntStream.range(0, newPostCount)
+                .mapToObj(i -> createPost(postType, writeMember))
+                .map(Post::getId)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+
+        // when
+        List<GetLatestPostsDto> postList = postRepository.findPostsWithinLast24Hours(postType, readerPostList);
+
+        // then
+        for(GetLatestPostsDto post : postList) {
+            List<Long> sortedPostIds = Arrays.stream(post.getPostIdList().split(","))
+                    .map(Long::valueOf)
+                    .sorted()
+                    .toList();
+
+            assertThat(sortedPostIds).isEqualTo(newPostList);
+        }
+    }
+}

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.bangbangbwa.backend.domain.sns.repository;
+
+import com.bangbangbwa.backend.global.test.RedisTest;
+import com.bangbangbwa.backend.global.util.randomValue.RandomValue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(ReaderPostRepository.class)
+class ReaderPostRepositoryTest extends RedisTest {
+
+    @Autowired
+    private ReaderPostRepository readerPostRepository;
+
+    @Test
+    void addReadPost_AND_findAllReadPostsByMemberId() {
+        // given
+        int postCount = RandomValue.getInt(0,5);
+
+        List<String> postIdList = IntStream.range(0, postCount)
+                .mapToObj(i -> String.valueOf(RandomValue.getRandomLong(0, 9999)))
+                .toList();
+
+
+        String memberId = String.valueOf(RandomValue.getRandomLong(0,9999));
+
+
+        // when
+        postIdList.forEach(i -> readerPostRepository.addReadPost(memberId, i));
+
+        // then
+        Set<String> postIds = readerPostRepository.findAllReadPostsByMemberId(memberId);
+        Set<String> expectedList = new HashSet<>(postIdList);
+        assertThat(expectedList).isEqualTo(postIds);
+    }
+}

--- a/src/test/java/com/bangbangbwa/backend/global/test/MyBatisTest.java
+++ b/src/test/java/com/bangbangbwa/backend/global/test/MyBatisTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles("test")
 @MybatisTest
 @TestPropertySource(properties = "logging.config=classpath:logback-spring-test.xml")
-@Import(MyBatisConfig.class)
+@Import({MyBatisConfig.class, DatabaseCleaner.class})
 abstract public class MyBatisTest {
 
 }

--- a/src/test/java/com/bangbangbwa/backend/global/test/RedisTest.java
+++ b/src/test/java/com/bangbangbwa/backend/global/test/RedisTest.java
@@ -1,0 +1,28 @@
+package com.bangbangbwa.backend.global.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+
+@ActiveProfiles("test")
+@DataRedisTest
+@TestPropertySource(properties = "logging.config=classpath:logback-spring-test.xml")
+abstract public class RedisTest {
+
+
+    @BeforeAll
+    static void setUpAll() throws IOException {
+        EmbeddedServer.startRedis();
+    }
+
+    @AfterAll
+    static void tearDownAll() throws IOException {
+        EmbeddedServer.stopRedis();
+    }
+
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

- getLatestPosts 기존 streamerId 기준 GROUP 되던 값 memberId 기준으로 GROUP 되도록 변경
- readerPost 관련 코드 추가 
사용자가 읽은 게시물의 경우 다시 반환되지 않도록 변경 

현재는 24시간 내의 모든 게시물을 읽어와 반환하고 있으나, 이후 갯수 제한 필요

## 🔖 반영 브랜치
- feature/BBB-85 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- 로그인 중 사용자가 게시물 상세 정보를 시도하면 해당 게시글을 읽은 게시물로 추가하도록 변경

## ➕ 이슈 링크

- [방송인 최신 글 표시 팔로우 관련 작업](https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-85)
