### PR TITLE
[BBB-87] 로그인 중 사용자가 게시물 상세 정보 후 해당 게시글을 읽은 게시물로 추가

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/controller/SnsController.java
@@ -41,7 +41,7 @@ public class SnsController implements SnsApi{
   }
 
   @GetMapping("/getPostDetails/{postId}")
-  @AuthenticationContext
+  @PreAuthorize("permitAll()")
   public ApiResponse<GetPostDetailsDto.Response> getPostDetails(@PathVariable("postId") Long postId) {
     GetPostDetailsDto.Response response = snsService.getPostDetails(postId);
     return ApiResponse.ok(response);

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
@@ -52,6 +52,7 @@ public class SnsService {
   private final ReportCommentCreator reportCommentCreator;
   private final DailyMessageReader dailyMessageReader;
   private final ReaderPostReader readerPostReader;
+  private final ReaderPostCreator readerPostCreator;
 
   // 게시글 저장 전, content에서 url을 추출 후 redis 값 삭제하는 과정 필요
   @Transactional
@@ -101,7 +102,9 @@ public class SnsService {
 
   public GetPostDetailsDto.Response getPostDetails(Long postId) {
     Long memberId = memberProvider.getCurrentMemberIdOrNull();
-    return postReader.getPostDetails(postId, memberId);
+    GetPostDetailsDto.Response response = postReader.getPostDetails(postId, memberId);
+    if (memberId != null) readerPostCreator.addReadPost(memberId, response.postId());
+    return response;
   }
 
   public List<Post> getPostList() {


### PR DESCRIPTION
## 🔎 작업 내용

- 로그인 중 사용자가 게시물 상세 정보 후 해당 게시글을 읽은 게시물로 추가
- 게시물 상세 조회 후 최근 게시글 목록 조회 하는 테스트 코드 작성

## 🔖 반영 브랜치
- feature/BBB-87 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- 게시물 목록 조회 팔로우 관련 작업

## ➕ 이슈 링크

- https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-87 
