### PR TITLE
[BBB-98] 로그인 사용자 게시물 목록 맞춤 조회

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
@@ -35,7 +35,8 @@ public class PostProvider {
 
     List<Post> followPost = getPostsByMemberIds(followPostSize, memberIds, readPostIds);
     List<Post> tagPost = getTagPost(tagPostSize, tagIds, readPostIds);
-    int randomPostSize = POST_SIZE - followPost.size() - tagPost.size();
+    int totalPosts = followPost.size() + tagPost.size();
+    int randomPostSize = Math.max(POST_SIZE - totalPosts, postProbability[2]);
     List<Post> randomPost = getRandomPost(postType, randomPostSize, readPostIds);
 
     return mergeUniquePosts(followPost, tagPost, randomPost);

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
@@ -3,7 +3,6 @@ package com.bangbangbwa.backend.domain.sns.business;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
 import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
 import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,14 +10,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostProvider {
 
-  // 게시물 반환 최대 갯수
+  // 게시물 반환 갯수
   private final int POST_SIZE = 7;
-  // 팔로우 게시물 반환 갯수
-  private int FOLLOW_POST_SIZE;
-  // 태그 게시물 반환 갯수
-  private int TAG_POST_SIZE;
-  // 현재까지 조회된 게시물
-  private Set<String> excludedPostIds = new HashSet<>();
 
 
   private final PostRecommendationStrategy postRecommendationStrategy;
@@ -32,58 +25,35 @@ public class PostProvider {
   }
 
   public List<Post> getMemberPersonalizedPosts(Long memberId, Set<String> readPostIds) {
-    initializePostSetup(readPostIds);
-    List<Post> followPost = getFollowPosts(memberId);
-    List<Post> tagPost = getTagPost(memberId);
-    List<Post> randomPost = getRandomPostsForMissingCount(PostType.STREAMER);
-    return mergeUniquePosts(followPost, tagPost, randomPost);
-  }
-
-  private void initializePostSetup(Set<String> readPostIds) {
-    setPostSize();
-    setExcludedPostIds(readPostIds);
-  }
-
-  private void setPostSize() {
-    int[] postProbability = postRecommendationStrategy.getPostReturnCount(POST_SIZE);
-    FOLLOW_POST_SIZE = postProbability[0];
-    TAG_POST_SIZE = postProbability[1];
-  }
-
-  private void setExcludedPostIds(Set<String> readPostIds) {
-    excludedPostIds.addAll(readPostIds);
+    List<Post> followPost = getFollowPosts(memberId, readPostIds);
+    List<Post> tagPost = getTagPost(memberId, readPostIds);
+    List<Post> randomPost = getRandomPost(PostType.STREAMER, readPostIds);
+    return postRecommendationStrategy.getPosts(followPost, tagPost, randomPost);
   }
 
 
-  private List<Post> getFollowPosts(Long memberId) {
-    List<Post> postList = postReader.findPostsByFollowStreamerExcludingReadIds(FOLLOW_POST_SIZE, memberId, excludedPostIds);
-    addExcludedPostIds(postList);
-    return postList;
+  private List<Post> getFollowPosts(Long memberId, Set<String> readPostIds) {
+    List<Post> posts = postReader.findPostsByFollowStreamerExcludingReadIds(POST_SIZE, memberId, readPostIds);
+    addReadPostIds(posts, readPostIds);
+    return posts;
   }
 
-  public List<Post> getTagPost(Long memberId) {
-    List<Post> postList = postReader.findPostsByFollowedStreamerExcludingReadIds(TAG_POST_SIZE, memberId, excludedPostIds);
-    addExcludedPostIds(postList);
-    return postList;
+  private List<Post> getTagPost(Long memberId, Set<String> readPostIds) {
+    List<Post> posts =  postReader.findPostsByFollowedStreamerExcludingReadIds(POST_SIZE, memberId, readPostIds);
+    addReadPostIds(posts, readPostIds);
+    return posts;
   }
 
-  private List<Post> getRandomPostsForMissingCount(PostType postType) {
-    int postSize = POST_SIZE - excludedPostIds.size();
-    return postReader.findRandomPostsExcludingReadIds(postType,postSize, excludedPostIds);
+  private List<Post> getRandomPost(PostType postType, Set<String> readPostIds) {
+    List<Post> posts =  postReader.findRandomPostsExcludingReadIds(postType,POST_SIZE, readPostIds);
+    addReadPostIds(posts, readPostIds);
+    return posts;
   }
 
-  public void addExcludedPostIds(List<Post> postList) {
-    excludedPostIds.addAll(postList.stream()
-            .map(post -> Long.toString(post.getId()))
-            .collect(Collectors.toSet()));
+  private void addReadPostIds(List<Post> posts, Set<String> readPostIds) {
+    posts.stream()
+        .map(Post::getId)
+        .map(String::valueOf)
+        .forEach(readPostIds::add);
   }
-
-  private List<Post> mergeUniquePosts(List<Post> followPost, List<Post> tagPost, List<Post> randomPost) {
-    Set<Post> uniquePosts = new HashSet<>();
-    uniquePosts.addAll(followPost);
-    uniquePosts.addAll(tagPost);
-    uniquePosts.addAll(randomPost);
-    return new ArrayList<>(uniquePosts);
-  }
-
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostProvider.java
@@ -2,8 +2,7 @@ package com.bangbangbwa.backend.domain.sns.business;
 
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
 import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +10,60 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostProvider {
 
+  // 게시물 반환 최대 갯수
+  private final int POST_SIZE = 7;
+
+  private final PostRecommendationStrategy postRecommendationStrategy;
   private final PostReader postReader;
 
+
   public List<Post> getRandomPost(PostType postType) {
-    List<Post> postList = postReader.findAllByPostType(postType);
+    List<Post> postList = postReader.findPostsByPostTypeWithLimit(postType, POST_SIZE);
     Collections.shuffle(postList);
-    return postList.subList(0, Math.min(postList.size(), 5));
+    return postList;
   }
+
+  public List<Post> getMemberPersonalizedPosts(Long memberId, Set<String> readPostIds) {
+    PostType postType = PostType.STREAMER;
+    List<Long> memberIds = new ArrayList<>();
+    // 해당 유저가 갖고 있는 tag ID 이 담겨있는 리스트
+    List<Long> tagIds = new ArrayList<>();
+
+    int[] postProbability = postRecommendationStrategy.getPostReturnCount(POST_SIZE);
+    int followPostSize = postProbability[0];
+    int tagPostSize = postProbability[1];
+
+    List<Post> followPost = getPostsByMemberIds(followPostSize, memberIds, readPostIds);
+    List<Post> tagPost = getTagPost(tagPostSize, tagIds, readPostIds);
+    int randomPostSize = POST_SIZE - followPost.size() - tagPost.size();
+    List<Post> randomPost = getRandomPost(postType, randomPostSize, readPostIds);
+
+    return mergeUniquePosts(followPost, tagPost, randomPost);
+  }
+
+  private List<Post> getRandomPost(PostType postType, int randomPostSize, Set<String> readPostIds) {
+    return postReader.findRandomPostsExcludingReadIds(postType,randomPostSize, readPostIds);
+  }
+
+
+  // note. 팔로우한 스트리머의 Id 값을 반환하는 작업 이후 추가
+  private List<Post> getPostsByMemberIds(int followPostSize, List<Long> memberIds, Set<String> readPostIds) {
+//    return postReader.findPostsByStreamerAndMemberIdsExcludingReadIds(followPostSize, memberIds, readPostIds);
+    return new ArrayList<>();
+  }
+
+  // note. Tag 값이 동일한 스트리머의 MemberIds 를 반환하는 작업 이후 추가
+  public List<Post> getTagPost(int tagPostSize, List<Long> tagIds, Set<String> readPostIds) {
+//    return postReader.findPostsByStreamerTagsExcludingReadIds(tagPostSize, tagIds, readPostIds);
+    return new ArrayList<>();
+  }
+
+  private List<Post> mergeUniquePosts(List<Post> followPost, List<Post> tagPost, List<Post> randomPost) {
+    Set<Post> uniquePosts = new HashSet<>();
+    uniquePosts.addAll(followPost);
+    uniquePosts.addAll(tagPost);
+    uniquePosts.addAll(randomPost);
+    return new ArrayList<>(uniquePosts);
+  }
+
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
@@ -42,15 +42,15 @@ public class PostReader {
     return postRepository.findByPostTypeAndRandomPostsExcludingReadIds(postType, limit, excludedPostIds);
   }
 
-  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> excludedPostIds) {
-    return postRepository.findPostsByStreamerTagsExcludingReadIds(limit, tagIds, excludedPostIds);
+  public List<Post> findPostsByFollowedStreamerExcludingReadIds(int limit, Long memberId, Set<String> excludedPostIds) {
+    return postRepository.findPostsByFollowedStreamerExcludingReadIds(limit, memberId, excludedPostIds);
   }
 
-  public List<Post> findPostsByStreamerAndMemberIdsExcludingReadIds(
+  public List<Post> findPostsByFollowStreamerExcludingReadIds(
           int limit,
-          List<Long> memberIds,
+          Long memberId,
           Set<String> excludedPostIds
   ) {
-    return postRepository.findPostsByStreamerAndMemberIdsExcludingReadIds(limit, memberIds, excludedPostIds);
+    return postRepository.findPostsByFollowStreamerExcludingReadIds(limit, memberId, excludedPostIds);
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
@@ -30,7 +30,27 @@ public class PostReader {
     return postRepository.findAllByPostType(postType);
   }
 
-  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType, Set<String> readerPostList) {
-    return postRepository.findPostsWithinLast24Hours(postType, readerPostList);
+  public List<Post> findPostsByPostTypeWithLimit(PostType postType, int size) {
+    return postRepository.findPostsByPostTypeWithLimit(postType, size);
+  }
+
+  public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType, Set<String> readPostIds) {
+    return postRepository.findPostsWithinLast24Hours(postType, readPostIds);
+  }
+
+  public List<Post> findRandomPostsExcludingReadIds(PostType postType, int limit, Set<String> readPostIds) {
+    return postRepository.findByPostTypeAndRandomPostsExcludingReadIds(postType, limit, readPostIds);
+  }
+
+  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> readPostIds) {
+    return postRepository.findPostsByStreamerTagsExcludingReadIds(limit, tagIds, readPostIds);
+  }
+
+  public List<Post> findPostsByStreamerAndMemberIdsExcludingReadIds(
+          int limit,
+          List<Long> memberIds,
+          Set<String> readPostIds
+  ) {
+    return postRepository.findPostsByStreamerAndMemberIdsExcludingReadIds(limit, memberIds, readPostIds);
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostReader.java
@@ -38,19 +38,19 @@ public class PostReader {
     return postRepository.findPostsWithinLast24Hours(postType, readPostIds);
   }
 
-  public List<Post> findRandomPostsExcludingReadIds(PostType postType, int limit, Set<String> readPostIds) {
-    return postRepository.findByPostTypeAndRandomPostsExcludingReadIds(postType, limit, readPostIds);
+  public List<Post> findRandomPostsExcludingReadIds(PostType postType, int limit, Set<String> excludedPostIds) {
+    return postRepository.findByPostTypeAndRandomPostsExcludingReadIds(postType, limit, excludedPostIds);
   }
 
-  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> readPostIds) {
-    return postRepository.findPostsByStreamerTagsExcludingReadIds(limit, tagIds, readPostIds);
+  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> excludedPostIds) {
+    return postRepository.findPostsByStreamerTagsExcludingReadIds(limit, tagIds, excludedPostIds);
   }
 
   public List<Post> findPostsByStreamerAndMemberIdsExcludingReadIds(
           int limit,
           List<Long> memberIds,
-          Set<String> readPostIds
+          Set<String> excludedPostIds
   ) {
-    return postRepository.findPostsByStreamerAndMemberIdsExcludingReadIds(limit, memberIds, readPostIds);
+    return postRepository.findPostsByStreamerAndMemberIdsExcludingReadIds(limit, memberIds, excludedPostIds);
   }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
@@ -13,8 +13,7 @@ public class PostRecommendationStrategy {
     private static final int[][] probabilities = {
             {70, 20, 10}, // 첫 번째 게시물
             {60, 25, 15}, // 두 번째 게시물
-            {50, 30, 20}, // 세 번째 게시물
-            {50, 30, 20}  // 네 번째 게시물 이후 고정 확률
+            {50, 30, 20}, // 이후    게시물
     };
 
 

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
@@ -1,40 +1,70 @@
 package com.bangbangbwa.backend.domain.sns.business;
 
+import com.bangbangbwa.backend.domain.sns.common.entity.Post;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 
 @Component
 public class PostRecommendationStrategy {
 
-    private final ThreadLocalRandom rand = ThreadLocalRandom.current();
+    private static final ThreadLocalRandom RAND = ThreadLocalRandom.current();
 
     // 각 게시물에 대한 확률 (팔로우한 사람, 비슷한 태그, 랜덤)
-    private static final int[][] probabilities = {
-            {70, 20, 10}, // 첫 번째 게시물
-            {60, 25, 15}, // 두 번째 게시물
-            {50, 30, 20}, // 이후    게시물
+    private static final int[][] PROBABILITIES = {
+        {70, 20, 10}, // 첫 번째 게시물
+        {60, 25, 15}, // 두 번째 게시물
+        {50, 30, 20}  // 이후 게시물
     };
 
+    private static final int MAX_POSTS = 7;
 
-    public int[] getPostReturnCount(int postSize) {
-        int[] result = {0, 0, 0}; // [0: 팔로우한 사람, 1: 비슷한 태그, 2: 랜덤]
+    public List<Post> getPosts(
+        List<Post> followPosts, List<Post> tagPosts, List<Post> randomPosts
+    ) {
+        List<Post> selectedPosts = new ArrayList<>();
+        IntStream.range(0, MAX_POSTS)
+            .mapToObj(i -> selectPost(i, followPosts, tagPosts, randomPosts, selectedPosts))
+            .filter(Objects::nonNull)
+            .forEach(selectedPosts::add);
+        return selectedPosts;
+    }
 
-        for (int i = 0; i < postSize; i++) {
-            int randomValue = rand.nextInt(100);
-            int[] currentProbabilities = probabilities[Math.min(i, probabilities.length - 1)];
 
-            int followProbability = currentProbabilities[0];
-            int tagProbability = followProbability + currentProbabilities[1];
+    private Post selectPost(
+        int num,
+        List<Post> followPosts,
+        List<Post> tagPosts,
+        List<Post> randomPosts,
+        List<Post> selectedPosts
+    ) {
+        int randomValue = RAND.nextInt(100);
+        int[] currentProbabilities = PROBABILITIES[Math.min(num, PROBABILITIES.length - 1)];
 
-            if (randomValue < followProbability) {
-                result[0]++;
-            } else if (randomValue < tagProbability) {
-                result[1]++;
-            } else {
-                result[2]++;
-            }
+        if (randomValue < currentProbabilities[0]) {
+            return findUniquePost(followPosts, tagPosts, randomPosts, selectedPosts);
+        } else if (randomValue < currentProbabilities[0] + currentProbabilities[1]) {
+            return findUniquePost(tagPosts, followPosts, randomPosts, selectedPosts);
+        } else {
+            return findUniquePost(randomPosts, followPosts, tagPosts, selectedPosts);
         }
-        return result;
+    }
+
+    private Post findUniquePost(
+        List<Post> firstPosts,
+        List<Post> secondPosts,
+        List<Post> thirdPosts,
+        List<Post> selectedPosts
+    ) {
+        return Stream.of(firstPosts, secondPosts, thirdPosts)
+            .flatMap(List::stream)
+            .filter(post -> !selectedPosts.contains(post))
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/business/PostRecommendationStrategy.java
@@ -1,0 +1,41 @@
+package com.bangbangbwa.backend.domain.sns.business;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class PostRecommendationStrategy {
+
+    private final ThreadLocalRandom rand = ThreadLocalRandom.current();
+
+    // 각 게시물에 대한 확률 (팔로우한 사람, 비슷한 태그, 랜덤)
+    private static final int[][] probabilities = {
+            {70, 20, 10}, // 첫 번째 게시물
+            {60, 25, 15}, // 두 번째 게시물
+            {50, 30, 20}, // 세 번째 게시물
+            {50, 30, 20}  // 네 번째 게시물 이후 고정 확률
+    };
+
+
+    public int[] getPostReturnCount(int postSize) {
+        int[] result = {0, 0, 0}; // [0: 팔로우한 사람, 1: 비슷한 태그, 2: 랜덤]
+
+        for (int i = 0; i < postSize; i++) {
+            int randomValue = rand.nextInt(100);
+            int[] currentProbabilities = probabilities[Math.min(i, probabilities.length - 1)];
+
+            int followProbability = currentProbabilities[0];
+            int tagProbability = followProbability + currentProbabilities[1];
+
+            if (randomValue < followProbability) {
+                result[0]++;
+            } else if (randomValue < tagProbability) {
+                result[1]++;
+            } else {
+                result[2]++;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
@@ -56,24 +56,24 @@ public class PostRepository {
     return mysql.selectList("PostMapper.findByPostTypeAndRandomPostsExcludingReadIds", params);
   }
 
-  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> readPostIds) {
+  public List<Post> findPostsByFollowedStreamerExcludingReadIds(int limit, Long memberId, Set<String> readPostIds) {
     Map<String, Object> params = new HashMap<>();
     params.put("limit", limit);
-    params.put("tagIds", tagIds);
+    params.put("memberId", memberId);
     params.put("readPostIds", readPostIds);
-    return mysql.selectList("PostMapper.findPostsByStreamerTagsExcludingReadIds", params);
+    return mysql.selectList("PostMapper.findPostsByFollowedStreamerExcludingReadIds", params);
   }
 
-  public List<Post> findPostsByStreamerAndMemberIdsExcludingReadIds(
+  public List<Post> findPostsByFollowStreamerExcludingReadIds(
           int limit,
-          List<Long> memberIds,
+          Long memberId,
           Set<String> readPostIds
   ) {
     Map<String, Object> params = new HashMap<>();
     params.put("limit", limit);
-    params.put("memberIds", memberIds);
+    params.put("memberId", memberId);
     params.put("readPostIds", readPostIds);
-    return mysql.selectList("PostMapper.findPostsByStreamerAndMemberIdsExcludingReadIds", params);
+    return mysql.selectList("PostMapper.findPostsByFollowStreamerExcludingReadIds", params);
   }
 
 }

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/PostRepository.java
@@ -27,6 +27,13 @@ public class PostRepository {
     return mysql.selectList("PostMapper.findAllByPostType", postType);
   }
 
+  public List<Post> findPostsByPostTypeWithLimit(PostType postType, int size) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("postType", postType);
+    params.put("size", size);
+    return mysql.selectList("PostMapper.findAllByPostType", params);
+  }
+
   public List<GetLatestPostsDto> findPostsWithinLast24Hours(PostType postType, Set<String> readerPostList) {
     Map<String, Object> params = new HashMap<>();
     params.put("postType", postType);
@@ -40,4 +47,34 @@ public class PostRepository {
     params.put("memberId", memberId);
     return Optional.ofNullable(mysql.selectOne("PostMapper.getPostDetails", params));
   }
+
+  public List<Post> findByPostTypeAndRandomPostsExcludingReadIds(PostType postType, int limit, Set<String> readPostIds) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("postType", postType);
+    params.put("limit", limit);
+    params.put("readPostIds", readPostIds);
+    return mysql.selectList("PostMapper.findByPostTypeAndRandomPostsExcludingReadIds", params);
+  }
+
+  public List<Post> findPostsByStreamerTagsExcludingReadIds(int limit, List<Long> tagIds, Set<String> readPostIds) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("limit", limit);
+    params.put("tagIds", tagIds);
+    params.put("readPostIds", readPostIds);
+    return mysql.selectList("PostMapper.findPostsByStreamerTagsExcludingReadIds", params);
+  }
+
+  public List<Post> findPostsByStreamerAndMemberIdsExcludingReadIds(
+          int limit,
+          List<Long> memberIds,
+          Set<String> readPostIds
+  ) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("limit", limit);
+    params.put("memberIds", memberIds);
+    params.put("readPostIds", readPostIds);
+    return mysql.selectList("PostMapper.findPostsByStreamerAndMemberIdsExcludingReadIds", params);
+  }
+
 }
+

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
@@ -104,12 +104,13 @@ public class SnsService {
     return postReader.getPostDetails(postId, memberId);
   }
 
+  // note. streamer 계정이 조회했을 때의 작업 필요
   public List<Post> getPostList() {
     Role role = memberProvider.getCurrentRole();
     PostType postType = postTypeProvider.getInversePostTypeForRole(role);
 
     if (role == Role.GUEST) { return postProvider.getRandomPost(postType); }
-
+    if (role == Role.STREAMER) { return postProvider.getRandomPost(postType); }
     Long memberId = memberProvider.getCurrentMemberId();
     Set<String> readPostIds = readerPostReader.findAllReadPostsByMemberId(memberId);
     return postProvider.getMemberPersonalizedPosts(memberId, readPostIds);

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
@@ -109,8 +109,7 @@ public class SnsService {
     Role role = memberProvider.getCurrentRole();
     PostType postType = postTypeProvider.getInversePostTypeForRole(role);
 
-    if (role == Role.GUEST) { return postProvider.getRandomPost(postType); }
-    if (role == Role.STREAMER) { return postProvider.getRandomPost(postType); }
+    if (role == Role.GUEST || role == Role.STREAMER) {return postProvider.getRandomPost(postType);}
     Long memberId = memberProvider.getCurrentMemberId();
     Set<String> readPostIds = readerPostReader.findAllReadPostsByMemberId(memberId);
     return postProvider.getMemberPersonalizedPosts(memberId, readPostIds);

--- a/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/service/SnsService.java
@@ -107,7 +107,12 @@ public class SnsService {
   public List<Post> getPostList() {
     Role role = memberProvider.getCurrentRole();
     PostType postType = postTypeProvider.getInversePostTypeForRole(role);
-    return postProvider.getRandomPost(postType);
+
+    if (role == Role.GUEST) { return postProvider.getRandomPost(postType); }
+
+    Long memberId = memberProvider.getCurrentMemberId();
+    Set<String> readPostIds = readerPostReader.findAllReadPostsByMemberId(memberId);
+    return postProvider.getMemberPersonalizedPosts(memberId, readPostIds);
   }
 
   public List<GetLatestPostsDto.Response> getLatestPosts(PostType postType) {

--- a/src/main/java/com/bangbangbwa/backend/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/tag/repository/MemberTagRepository.java
@@ -1,0 +1,24 @@
+package com.bangbangbwa.backend.domain.tag.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberTagRepository {
+
+    private final SqlSession mysql;
+
+    @Transactional
+    public void save(Long memberId, Long tagId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberId", memberId);
+        params.put("tagId", tagId);
+        mysql.insert("MemberTagMapper.save", params);
+    }
+}

--- a/src/main/resources/mybatis/map/post.xml
+++ b/src/main/resources/mybatis/map/post.xml
@@ -17,6 +17,10 @@
     SELECT * FROM posts WHERE post_type = #{postType};
   </select>
 
+  <select id="findPostsByPostTypeWithLimit" parameterType="map" resultType="post">
+    SELECT * FROM posts WHERE post_type = #{postType} LIMIT #{size};
+  </select>
+
 
   <resultMap id="GetLatestPostsDtoMap" type="com.bangbangbwa.backend.domain.sns.common.dto.GetLatestPostsDto">
     <result property="memberId" column="memberId" />
@@ -60,11 +64,68 @@
       ELSE false
     END AS isFollowed
     FROM posts p
-    LEFT JOIN members m ON p.member_id = m.id
+      LEFT JOIN members m ON p.member_id = m.id
     LEFT JOIN comments c ON c.post_id = p.id AND c.member_id = #{memberId}
     LEFT JOIN follow f ON f.follower_id = #{memberId} AND f.followee_id = p.member_id
     WHERE p.id = #{postId}
   </select>
 
+
+
+  <select id="findByPostTypeAndRandomPostsExcludingReadIds" parameterType="map" resultType="post">
+    SELECT *
+    FROM posts
+    WHERE post_type = #{postType}
+    <if test="readPostIds != null and readPostIds.size() > 0">
+      AND id NOT IN
+      <foreach item="id" collection="readPostIds" open="(" separator="," close=")">
+        #{id}
+      </foreach>
+    </if>
+    ORDER BY RAND()
+    LIMIT #{limit}
+  </select>
+
+
+  <select id="findPostsByStreamerTagsExcludingReadIds" parameterType="map" resultType="post">
+    SELECT p.*
+    FROM posts p
+    WHERE p.post_type = 'STREAMER'
+    AND p.member_id IN (
+    SELECT s.member_id
+    FROM streamers s
+    JOIN streamers_tags st ON s.id = st.streamer_id
+    WHERE st.tag_id IN
+    <foreach item="tagId" collection="tagIds" open="(" separator="," close=")">
+      #{tagId}
+    </foreach>
+    )
+    <if test="readPostIds != null and readPostIds.size() > 0">
+      AND p.id NOT IN
+      <foreach item="id" collection="readPostIds" open="(" separator="," close=")">
+        #{id}
+      </foreach>
+    </if>
+    LIMIT #{limit}
+  </select>
+
+
+
+  <select id="findPostsByStreamerAndMemberIdsExcludingReadIds" parameterType="map" resultType="Post">
+    SELECT p.*
+    FROM posts p
+    WHERE p.post_type = 'STREAMER'
+    AND p.member_id IN
+    <foreach item="memberId" collection="memberIds" open="(" separator="," close=")">
+      #{memberId}
+    </foreach>
+    <if test="readPostIds != null and readPostIds.size() > 0">
+      AND p.id NOT IN
+      <foreach item="id" collection="readPostIds" open="(" separator="," close=")">
+        #{id}
+      </foreach>
+    </if>
+    LIMIT #{limit}
+  </select>
 
 </mapper>

--- a/src/main/resources/mybatis/map/post.xml
+++ b/src/main/resources/mybatis/map/post.xml
@@ -87,18 +87,23 @@
   </select>
 
 
-  <select id="findPostsByStreamerTagsExcludingReadIds" parameterType="map" resultType="post">
+
+  <select id="findPostsByFollowedStreamerExcludingReadIds" parameterType="map" resultType="post">
     SELECT p.*
     FROM posts p
     WHERE p.post_type = 'STREAMER'
     AND p.member_id IN (
     SELECT s.member_id
     FROM streamers s
-    JOIN streamers_tags st ON s.id = st.streamer_id
-    WHERE st.tag_id IN
-    <foreach item="tagId" collection="tagIds" open="(" separator="," close=")">
-      #{tagId}
-    </foreach>
+    WHERE s.id IN (
+    SELECT st.streamer_id
+    FROM streamers_tags st
+    WHERE st.tag_id IN (
+    SELECT mt.tag_id
+    FROM members_tags mt
+    WHERE mt.member_id = #{memberId}
+    )
+    )
     )
     <if test="readPostIds != null and readPostIds.size() > 0">
       AND p.id NOT IN
@@ -111,14 +116,17 @@
 
 
 
-  <select id="findPostsByStreamerAndMemberIdsExcludingReadIds" parameterType="map" resultType="Post">
+
+
+  <select id="findPostsByFollowStreamerExcludingReadIds" parameterType="map" resultType="Post">
     SELECT p.*
     FROM posts p
     WHERE p.post_type = 'STREAMER'
-    AND p.member_id IN
-    <foreach item="memberId" collection="memberIds" open="(" separator="," close=")">
-      #{memberId}
-    </foreach>
+    AND p.member_id IN (
+    SELECT f.followee_id
+    FROM follow f
+    WHERE f.follower_id = #{memberId}
+    )
     <if test="readPostIds != null and readPostIds.size() > 0">
       AND p.id NOT IN
       <foreach item="id" collection="readPostIds" open="(" separator="," close=")">

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
@@ -15,6 +15,8 @@ import com.bangbangbwa.backend.domain.member.repository.FollowRepository;
 import com.bangbangbwa.backend.domain.member.repository.MemberRepository;
 import com.bangbangbwa.backend.domain.oauth.common.dto.OAuthInfoDto;
 import com.bangbangbwa.backend.domain.oauth.common.enums.SnsType;
+import com.bangbangbwa.backend.domain.promotion.common.entity.Streamer;
+import com.bangbangbwa.backend.domain.promotion.repository.StreamerRepository;
 import com.bangbangbwa.backend.domain.sns.common.dto.*;
 import com.bangbangbwa.backend.domain.sns.common.entity.Comment;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
@@ -27,6 +29,10 @@ import com.bangbangbwa.backend.domain.sns.exception.InvalidMemberVisibilityExcep
 import com.bangbangbwa.backend.domain.sns.repository.*;
 import com.bangbangbwa.backend.domain.sns.exception.NotFoundPostException;
 import com.bangbangbwa.backend.domain.streamer.repository.DailyMessageRepository;
+import com.bangbangbwa.backend.domain.streamer.repository.StreamerTagRepository;
+import com.bangbangbwa.backend.domain.tag.common.entity.Tag;
+import com.bangbangbwa.backend.domain.tag.repository.MemberTagRepository;
+import com.bangbangbwa.backend.domain.tag.repository.TagRepository;
 import com.bangbangbwa.backend.domain.token.business.TokenProvider;
 import com.bangbangbwa.backend.domain.token.common.TokenDto;
 import com.bangbangbwa.backend.global.response.ApiResponse;
@@ -86,6 +92,18 @@ class SnsIntegrationTest extends IntegrationTest {
 
   @Autowired
   private TokenProvider tokenProvider;
+
+  @Autowired
+  private TagRepository tagRepository;
+
+  @Autowired
+  private MemberTagRepository memberTagRepository;
+
+  @Autowired
+  private StreamerRepository streamerRepository;
+
+  @Autowired
+  private StreamerTagRepository streamerTagRepository;
 
   @MockBean
   private S3Manager s3Manager;
@@ -179,6 +197,95 @@ class SnsIntegrationTest extends IntegrationTest {
     return reportComment;
   }
 
+  private Tag getTag() {
+    String name = RandomValue.string(10,15).setNullable(false).get();
+    return Tag.builder().createdId("test").name(name).build();
+  }
+
+  private Tag createTag() {
+    Tag tag = getTag();
+    tagRepository.save(tag);
+    return tag;
+  }
+
+  private Streamer getStreamer(Member member) {
+    return Streamer.builder().memberId(member.getId()).build();
+  }
+
+  private Streamer createStreamer(Member member) {
+    Streamer streamer = getStreamer(member);
+    streamerRepository.save(streamer);
+    return streamer;
+  }
+
+
+
+  @Test()
+  void getPostList_토큰_보유_멤버() {
+    // given
+    int POST_SIZE = 7;
+    Role memberRole = Role.MEMBER;
+    PostType postType = PostType.STREAMER;
+    Member member = getMember();
+    member.updateRole(memberRole);
+    memberRepository.save(member);
+
+    Tag tag = createTag();
+    memberTagRepository.save(member.getId(), tag.getId());
+
+    TokenDto tokenDto = tokenProvider.getToken(member);
+
+    Member writeMember = createMember();
+    int postCount = RandomValue.getInt(0,5);
+    List<Post> postList = IntStream.range(0, postCount)
+        .mapToObj(i -> createPost(postType, writeMember))
+        .toList();
+
+    Member writeFollowMember = createMember();
+    createFollow(member, writeFollowMember);
+    int followPostCount = RandomValue.getInt(0,5);
+    List<Post> followPostList = IntStream.range(0, followPostCount)
+        .mapToObj(i -> createPost(postType, writeFollowMember))
+        .toList();
+
+    Member writeTagMember = createMember();
+    Streamer streamer = createStreamer(writeTagMember);
+    streamerRepository.save(streamer);
+    streamerTagRepository.save(streamer.getId(), tag);
+    int tagPostCount = RandomValue.getInt(0,5);
+    List<Post> tagPostList = IntStream.range(0, tagPostCount)
+        .mapToObj(i -> createPost(postType, writeTagMember))
+        .toList();
+
+    int totalPostCount = Math.min(POST_SIZE, tagPostCount + followPostCount + postCount);
+
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(tokenDto.getAccessToken());
+    HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+    String url = "http://localhost:" + port + "/api/v1/sns/getPostList";
+
+
+    // when
+    ResponseEntity<String> responseEntity = restTemplate.exchange(
+        url,
+        HttpMethod.GET,
+        requestEntity,
+        String.class
+    );
+
+    ApiResponse<List<GetPostListDto.Response>> apiResponse = gson.fromJson(
+        responseEntity.getBody(),
+        new TypeToken<ApiResponse<List<GetPostListDto.Response>>>() {}.getType()
+    );
+
+    // then
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertNotNull(apiResponse.getData());
+    assertThat(apiResponse.getData().size()).isEqualTo(totalPostCount);
+
+  }
 
   // note. 이미지/동영상 여부 값 비교 필요
   @Test
@@ -241,6 +348,7 @@ class SnsIntegrationTest extends IntegrationTest {
 
     assertThat(actualList).usingRecursiveComparison().isEqualTo(expectedList);
   }
+
 
   @Test
   void getPostList_토큰_미입력() {

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
@@ -182,7 +182,7 @@ class SnsIntegrationTest extends IntegrationTest {
 
   // note. 이미지/동영상 여부 값 비교 필요
   @Test
-  void getPostList() {
+  void getPostList_토큰_보유() {
     // given
     Role memberRole = (RandomValue.getInt(2) == 1) ? Role.MEMBER : Role.STREAMER;
     PostType postType = (memberRole == Role.MEMBER) ? PostType.STREAMER : PostType.MEMBER;

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
@@ -1,12 +1,18 @@
 package com.bangbangbwa.backend.domain.sns.repository;
 
 import com.bangbangbwa.backend.domain.member.common.entity.Member;
+import com.bangbangbwa.backend.domain.member.repository.FollowRepository;
 import com.bangbangbwa.backend.domain.member.repository.MemberRepository;
 import com.bangbangbwa.backend.domain.oauth.common.dto.OAuthInfoDto;
 import com.bangbangbwa.backend.domain.oauth.common.enums.SnsType;
+import com.bangbangbwa.backend.domain.promotion.common.entity.Streamer;
+import com.bangbangbwa.backend.domain.promotion.repository.StreamerRepository;
 import com.bangbangbwa.backend.domain.sns.common.dto.GetLatestPostsDto;
 import com.bangbangbwa.backend.domain.sns.common.entity.Post;
 import com.bangbangbwa.backend.domain.sns.common.enums.PostType;
+import com.bangbangbwa.backend.domain.streamer.repository.StreamerTagRepository;
+import com.bangbangbwa.backend.domain.tag.common.entity.Tag;
+import com.bangbangbwa.backend.domain.tag.repository.TagRepository;
 import com.bangbangbwa.backend.global.test.MyBatisTest;
 import com.bangbangbwa.backend.global.util.randomValue.RandomValue;
 import org.junit.jupiter.api.Test;
@@ -20,7 +26,14 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@Import({PostRepository.class, MemberRepository.class})
+@Import({
+        PostRepository.class,
+        MemberRepository.class,
+        StreamerRepository.class,
+        StreamerTagRepository.class,
+        TagRepository.class,
+        FollowRepository.class,
+})
 class PostRepositoryTest extends MyBatisTest {
 
     @Autowired
@@ -28,6 +41,18 @@ class PostRepositoryTest extends MyBatisTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private StreamerRepository streamerRepository;
+
+    @Autowired
+    private StreamerTagRepository streamerTagRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
 
 
     private Member getMember() {
@@ -66,6 +91,29 @@ class PostRepositoryTest extends MyBatisTest {
         return post;
     }
 
+    private Streamer getStreamer(Member member) {
+        return Streamer.builder().memberId(member.getId()).build();
+    }
+
+    private Streamer createStreamer(Member member) {
+        Streamer streamer = getStreamer(member);
+        streamerRepository.save(streamer);
+        return streamer;
+    }
+
+    private Tag getTag() {
+        return Tag.builder()
+                .name(RandomValue.string(1,10).setNullable(false).get())
+                .createdId("id")
+                .build();
+    }
+
+    private Tag createTag() {
+        Tag tag = getTag();
+        tagRepository.save(tag);
+        return tag;
+    }
+
     @Test()
     void findPostsWithinLast24Hours() {
         // given
@@ -98,4 +146,178 @@ class PostRepositoryTest extends MyBatisTest {
             assertThat(sortedPostIds).isEqualTo(newPostList);
         }
     }
+
+    @Test()
+    void findByPostTypeAndRandomPostsExcludingReadIds() {
+        // given
+        Member writeMember = createMember();
+        PostType postType = RandomValue.getRandomEnum(PostType.class);
+        int readPostCount = RandomValue.getInt(2);
+        int newPostCount = RandomValue.getInt(3);
+
+        Set<String> readerPostList = IntStream.range(0, readPostCount)
+                .mapToObj(i -> createPost(postType, writeMember).getId().toString())
+                .collect(Collectors.toSet());
+
+        List<Long> newPostList = IntStream.range(0, newPostCount)
+                .mapToObj(i -> createPost(postType, writeMember))
+                .map(Post::getId)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+
+        // when
+        List<Post> posts = postRepository.findByPostTypeAndRandomPostsExcludingReadIds(
+                postType,
+                3,
+                readerPostList
+        );
+
+        // then
+        assertThat(posts.size()).isEqualTo(newPostCount);
+        IntStream.range(0, posts.size())
+                .forEach(i -> assertThat(posts.get(i).getId()).isEqualTo(newPostList.get(i)));
+
+    }
+
+    @Test
+    void findPostsByStreamerTags() {
+        // given
+        int postLimit = 3;
+        int tagCount = RandomValue.getInt(1, 5);
+        int readPostCount = RandomValue.getInt(2);
+        int postCount = RandomValue.getInt(0,5);
+
+        Member writeMember = createMember();
+        Streamer streamer = createStreamer(writeMember);
+        Tag tag = createTag();
+        List<Long> tagIds = Collections.singletonList(tag.getId());
+        IntStream.range(0, tagCount)
+                .forEach(i->streamerTagRepository.save(streamer.getId(), tag));
+
+        IntStream.range(0, postCount)
+                .forEach(i->createPost(PostType.STREAMER, writeMember));
+
+        Set<String> readerPostList = IntStream.range(0, readPostCount)
+                .mapToObj(i -> createPost(PostType.STREAMER, writeMember).getId().toString())
+                .collect(Collectors.toSet());
+
+
+        // when
+        List<Post> posts = postRepository.findPostsByStreamerTagsExcludingReadIds(postLimit, tagIds, readerPostList);
+
+        // then
+        assertThat(posts.size()).isEqualTo(Math.min(postCount, postLimit));
+    }
+
+    @Test()
+    void findPostsByStreamerAndMemberIds() {
+        // given
+        int postLimit = 3;
+        int postCount = RandomValue.getInt(0,5);
+        int readPostCount = RandomValue.getInt(2);
+        int nonReturnedPostCount = RandomValue.getInt(0,5);
+        PostType postType = PostType.STREAMER;
+
+        IntStream.range(0, nonReturnedPostCount)
+                .forEach(i->createPost(postType, createMember()));
+
+        List<Long> membersId = IntStream.range(0, postCount)
+                .mapToObj(i -> {
+                    Member writeMember = createMember();
+                    Post post = createPost(PostType.STREAMER, writeMember);
+                    return post.getMemberId();
+                })
+                .toList();
+
+        Member member = createMember();
+        Set<String> readerPostList = IntStream.range(0, readPostCount)
+                .mapToObj(i -> createPost(PostType.STREAMER, member).getId().toString())
+                .collect(Collectors.toSet());
+
+
+        //when
+        List<Post> postList = postRepository.findPostsByStreamerAndMemberIdsExcludingReadIds(
+                postLimit,
+                membersId,
+                readerPostList
+        );
+
+        //then
+        int expectedPostCount = Math.min(postCount, postLimit);
+        assertThat(postList.size()).isEqualTo(expectedPostCount);
+        IntStream.range(0, expectedPostCount)
+                .forEach(i -> assertThat(postList.get(i).getMemberId()).isEqualTo(membersId.get(i)));
+    }
+//    @Test()
+//    void getUnreadAndFilteredPosts() throws Exception {
+//
+//        // given
+//        Member randomMember = createMember();
+//        Streamer randomStreamer = createStreamer(randomMember);
+//        Member followMember = createMember();
+//        Streamer followStreamer = createStreamer(followMember);
+//        Member tagMember = createMember();
+//        Streamer tagStreamer = createStreamer(tagMember);
+//
+//        List<Long> tags = IntStream.range(0, 3)
+//                .mapToObj(i -> createTag())
+//                .peek(tag -> streamerTagRepository.save(tagStreamer.getId(), tag))
+//                .map(Tag::getId)
+//                .toList();
+//
+//        List<Long> randomPost = IntStream.range(0, 3)
+//                .mapToObj(i -> createPost(PostType.STREAMER, randomMember))
+//                .map(Post::getId)
+//                .toList();
+//
+//        List<Long> followPost = IntStream.range(0, 3)
+//                .mapToObj(i -> createPost(PostType.STREAMER, followMember))
+//                .map(Post::getId)
+//                .toList();
+//
+//        List<Long> tagPost = IntStream.range(0, 3)
+//                .mapToObj(i -> createPost(PostType.STREAMER, tagMember))
+//                .map(Post::getId)
+//                .toList();
+//
+//        List<Long> allPosts = Stream.of(randomPost, followPost, tagPost)
+//                .flatMap(List::stream)
+//                .collect(Collectors.toList());
+//        Collections.shuffle(allPosts);
+//        List<Long> readPosts = allPosts.subList(0, 2);
+//
+//        List<Post> postList = postRepository.findAllByPostType(PostType.STREAMER);
+//        for (Post post : postList) {
+//            System.out.println(post.getId());
+//        }
+//
+//        // when
+////        GetStreamerPostsByTypeDto reponse = postRepository.getUnreadAndFilteredPosts(tags, readPosts, 3)
+////                .orElseThrow(Exception::new);
+//        GetStreamerPostsByTypeDto reponse = postRepository.getUnreadAndFilteredPosts(tags, readPosts, 3)
+//                .orElseThrow(Exception::new);
+//        // then
+//
+//        System.out.println("=Post=");
+////        for (GetStreamerPostsByTypeDto.Post post : reponse.getPosts()) {
+////            System.out.print(post.getPostId() + " ");
+////        }
+//        System.out.println();
+//        System.out.println("=Post=");
+//
+//        System.out.println("=FollowPost=");
+////        for (GetStreamerPostsByTypeDto.FollowedPost post : reponse.getFollowedPosts()) {
+////            System.out.print(post.postId() + " ");
+////        }
+////        System.out.println("=FollowPost=");
+////
+////        System.out.println("=TagPost=");
+////        for (GetStreamerPostsByTypeDto.TagPost post : reponse.getTagPosts()) {
+////            System.out.print(post.postId() + " ");
+////        }
+//        System.out.println("=TagPost=");
+//
+//
+//    }
+
 }

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
@@ -174,9 +174,13 @@ class PostRepositoryTest extends MyBatisTest {
 
         // then
         assertThat(posts.size()).isEqualTo(newPostCount);
-        IntStream.range(0, posts.size())
-                .forEach(i -> assertThat(posts.get(i).getId()).isEqualTo(newPostList.get(i)));
 
+        List<Post> sortedPosts = posts.stream().sorted(Comparator.comparing(Post::getId)).toList();
+        List<Long> sortedNewPostList = newPostList.stream().sorted().toList();
+
+        IntStream.range(0, sortedPosts.size())
+                .forEach(i -> assertThat(sortedPosts.get(i).getId())
+                        .isEqualTo(sortedNewPostList.get(i)));
     }
 
     @Test

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/PostRepositoryTest.java
@@ -213,15 +213,14 @@ class PostRepositoryTest extends MyBatisTest {
     void findPostsByStreamerAndMemberIds() {
         // given
         int postLimit = 3;
-        int postCount = RandomValue.getInt(0,5);
-        int readPostCount = RandomValue.getInt(2);
+        int readPostCount = RandomValue.getInt(0,5);
         int nonReturnedPostCount = RandomValue.getInt(0,5);
         PostType postType = PostType.STREAMER;
 
         IntStream.range(0, nonReturnedPostCount)
                 .forEach(i->createPost(postType, createMember()));
 
-        List<Long> membersId = IntStream.range(0, postCount)
+        List<Long> membersId = IntStream.range(0, readPostCount)
                 .mapToObj(i -> {
                     Member writeMember = createMember();
                     Post post = createPost(PostType.STREAMER, writeMember);
@@ -243,7 +242,7 @@ class PostRepositoryTest extends MyBatisTest {
         );
 
         //then
-        int expectedPostCount = Math.min(postCount, postLimit);
+        int expectedPostCount = Math.min(readPostCount, postLimit);
         assertThat(postList.size()).isEqualTo(expectedPostCount);
         IntStream.range(0, expectedPostCount)
                 .forEach(i -> assertThat(postList.get(i).getMemberId()).isEqualTo(membersId.get(i)));


### PR DESCRIPTION
## 🔎 작업 내용

- 로그인 사용자 게시물 목록 맞춤 조회

**동작 순서**
1. 총 반환 게시물 갯수만큼 [팔로우한 유저의 게시물] 를 조회
2. 조회한 값을 제외하고 총 반환 게시물 갯수만큼 [동일 태그 유저의 게시물] 을 조회
3. 현재까지 조회한 값을 제외하고 총 반환 게시물 갯수만큼의 [랜덤한 게시물] 을 조회
4. 조회한 게시물을 아래의 확률에 따라 반환되는 게시물을 선정
5. 선정된 게시물을 반환

**확률**
순서 -> [팔로우한 유저의 게시물 ], [ 동일 태그 유저의 게시물 ], [ 랜덤 게시물 ]
첫 번째 게시물 -> 70 , 20 , 10
두 번째 게시물 -> 60 , 25 , 15
이후 게시물 -> 50 , 30 , 20


방송 모드 조회는 이후 작업에서 진행할 예정

## 🔖 반영 브랜치
- feature/BBB-98 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

- Follow 관련 작업
- Tag 관련 작업
- 방송 모드 조회

## ➕ 이슈 링크

- https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-98
