### PR TITLE
[BBB-125] 읽은 게시물 반환 되지 않는 로직 임시 제거

### DIFF
--- a/src/main/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepository.java
+++ b/src/main/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepository.java
@@ -20,9 +20,9 @@ public class ReaderPostRepository {
     private static final long EXPIRATION_TIME = 30;
 
     public void addReadPost(String memberId, String postId) {
-        String key = PREFIX + memberId;
-        redisTemplate.opsForSet().add(key, postId);
-        redisTemplate.expire(key, EXPIRATION_TIME, EXPIRATION_UNIT);
+//        String key = PREFIX + memberId;
+//        redisTemplate.opsForSet().add(key, postId);
+//        redisTemplate.expire(key, EXPIRATION_TIME, EXPIRATION_UNIT);
     }
 
     public Set<String> findAllReadPostsByMemberId(String memberId) {

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/controller/SnsIntegrationTest.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -887,7 +888,7 @@ class SnsIntegrationTest extends IntegrationTest {
   }
 
 
-  @Test
+  @Test()
   void getLatestPosts_토큰_보유() {
     // given
     Member member = createMember();
@@ -900,11 +901,12 @@ class SnsIntegrationTest extends IntegrationTest {
     int readPostCount = RandomValue.getInt(0, 5);
     int newPostCount = RandomValue.getInt(0, 5);
 
-    IntStream.range(0, readPostCount)
-        .forEach(a -> {
-          Post post = createPost(PostType.STREAMER, writeMember);
-          readerPostRepository.addReadPost(member.getId().toString(), post.getId().toString());
-        });
+    // 읽은 게시물 반환 되지 않도록 수정 후 주석 해제
+//    IntStream.range(0, readPostCount)
+//        .forEach(a -> {
+//          Post post = createPost(PostType.STREAMER, writeMember);
+//          readerPostRepository.addReadPost(member.getId().toString(), post.getId().toString());
+//        });
 
     List<Long> postList = IntStream.range(0, newPostCount)
         .mapToObj(a -> createPost(PostType.STREAMER, writeMember))
@@ -1271,63 +1273,64 @@ class SnsIntegrationTest extends IntegrationTest {
   }
 
 
-  @Test
-  void getPostDetails_후_getLatestPosts() {
-    // given
-    int postCount = 0;
-
-    Member member = createMember();
-    TokenDto tokenDto = tokenProvider.getToken(member);
-
-    Member writeMember = createMember();
-    PostType postType = RandomValue.getRandomEnum(PostType.class);
-    Post post = createPost(postType, writeMember);
-
-    String getPostDetailsUrl =
-        "http://localhost:" + port + "/api/v1/sns/getPostDetails/" + post.getId();
-    String getLatestPostsUrl = "http://localhost:" + port + "/api/v1/sns/getLatestPosts";
-
-    HttpHeaders headers = new HttpHeaders();
-    headers.setBearerAuth(tokenDto.getAccessToken());
-    HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
-
-    // when
-    ResponseEntity<String> getPostDetailsResponse = restTemplate.exchange(
-        getPostDetailsUrl,
-        HttpMethod.GET,
-        requestEntity,
-        String.class);
-
-    ApiResponse<GetPostDetailsDto.Response> postDetailsApiResponse = gson.fromJson(
-        getPostDetailsResponse.getBody(),
-        new TypeToken<ApiResponse<GetPostDetailsDto.Response>>() {
-        }.getType()
-    );
-
-    ResponseEntity<String> getLatestPostsResponse = restTemplate.exchange(
-        getLatestPostsUrl,
-        HttpMethod.GET,
-        requestEntity,
-        String.class
-    );
-
-    ApiResponse<List<GetLatestPostsDto.Response>> latestPostsApiResponse = gson.fromJson(
-        getLatestPostsResponse.getBody(),
-        new TypeToken<ApiResponse<List<GetLatestPostsDto.Response>>>() {
-        }.getType()
-    );
-
-    // then
-    assertThat(getPostDetailsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertNotNull(postDetailsApiResponse.getData());
-    assertThat(postDetailsApiResponse.getData().postId()).isEqualTo(post.getId());
-    assertThat(postDetailsApiResponse.getData().writerId()).isEqualTo(writeMember.getId());
-    assertThat(postDetailsApiResponse.getData().title()).isEqualTo(post.getTitle());
-    assertThat(postDetailsApiResponse.getData().nickname()).isEqualTo(writeMember.getNickname());
-    assertThat(postDetailsApiResponse.getData().profileUrl()).isEqualTo(writeMember.getProfile());
-    assertThat(postDetailsApiResponse.getData().content()).isEqualTo(post.getContent());
-
-    assertThat(latestPostsApiResponse.getData().size()).isEqualTo(postCount);
-
-  }
+  // 읽은 게시물 반환 되지 않도록 수정 후 주석 해제
+//  @Test()
+//  void getPostDetails_후_getLatestPosts() {
+//    // given
+//    int postCount = 0;
+//
+//    Member member = createMember();
+//    TokenDto tokenDto = tokenProvider.getToken(member);
+//
+//    Member writeMember = createMember();
+//    PostType postType = RandomValue.getRandomEnum(PostType.class);
+//    Post post = createPost(postType, writeMember);
+//
+//    String getPostDetailsUrl =
+//        "http://localhost:" + port + "/api/v1/sns/getPostDetails/" + post.getId();
+//    String getLatestPostsUrl = "http://localhost:" + port + "/api/v1/sns/getLatestPosts";
+//
+//    HttpHeaders headers = new HttpHeaders();
+//    headers.setBearerAuth(tokenDto.getAccessToken());
+//    HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+//
+//    // when
+//    ResponseEntity<String> getPostDetailsResponse = restTemplate.exchange(
+//        getPostDetailsUrl,
+//        HttpMethod.GET,
+//        requestEntity,
+//        String.class);
+//
+//    ApiResponse<GetPostDetailsDto.Response> postDetailsApiResponse = gson.fromJson(
+//        getPostDetailsResponse.getBody(),
+//        new TypeToken<ApiResponse<GetPostDetailsDto.Response>>() {
+//        }.getType()
+//    );
+//
+//    ResponseEntity<String> getLatestPostsResponse = restTemplate.exchange(
+//        getLatestPostsUrl,
+//        HttpMethod.GET,
+//        requestEntity,
+//        String.class
+//    );
+//
+//    ApiResponse<List<GetLatestPostsDto.Response>> latestPostsApiResponse = gson.fromJson(
+//        getLatestPostsResponse.getBody(),
+//        new TypeToken<ApiResponse<List<GetLatestPostsDto.Response>>>() {
+//        }.getType()
+//    );
+//
+//    // then
+//    assertThat(getPostDetailsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+//    assertNotNull(postDetailsApiResponse.getData());
+//    assertThat(postDetailsApiResponse.getData().postId()).isEqualTo(post.getId());
+//    assertThat(postDetailsApiResponse.getData().writerId()).isEqualTo(writeMember.getId());
+//    assertThat(postDetailsApiResponse.getData().title()).isEqualTo(post.getTitle());
+//    assertThat(postDetailsApiResponse.getData().nickname()).isEqualTo(writeMember.getNickname());
+//    assertThat(postDetailsApiResponse.getData().profileUrl()).isEqualTo(writeMember.getProfile());
+//    assertThat(postDetailsApiResponse.getData().content()).isEqualTo(post.getContent());
+//
+//    assertThat(latestPostsApiResponse.getData().size()).isEqualTo(postCount);
+//
+//  }
 }

--- a/src/test/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepositoryTest.java
+++ b/src/test/java/com/bangbangbwa/backend/domain/sns/repository/ReaderPostRepositoryTest.java
@@ -20,25 +20,26 @@ class ReaderPostRepositoryTest extends RedisTest {
     @Autowired
     private ReaderPostRepository readerPostRepository;
 
-    @Test
-    void addReadPost_AND_findAllReadPostsByMemberId() {
-        // given
-        int postCount = RandomValue.getInt(0,5);
-
-        List<String> postIdList = IntStream.range(0, postCount)
-                .mapToObj(i -> String.valueOf(RandomValue.getRandomLong(0, 9999)))
-                .toList();
-
-
-        String memberId = String.valueOf(RandomValue.getRandomLong(0,9999));
-
-
-        // when
-        postIdList.forEach(i -> readerPostRepository.addReadPost(memberId, i));
-
-        // then
-        Set<String> postIds = readerPostRepository.findAllReadPostsByMemberId(memberId);
-        Set<String> expectedList = new HashSet<>(postIdList);
-        assertThat(expectedList).isEqualTo(postIds);
-    }
+// 읽은 게시물 반환 되지 않도록 수정 후 주석 해제
+//    @Test
+//    void addReadPost_AND_findAllReadPostsByMemberId() {
+//        // given
+//        int postCount = RandomValue.getInt(0,5);
+//
+//        List<String> postIdList = IntStream.range(0, postCount)
+//                .mapToObj(i -> String.valueOf(RandomValue.getRandomLong(0, 9999)))
+//                .toList();
+//
+//
+//        String memberId = String.valueOf(RandomValue.getRandomLong(0,9999));
+//
+//
+//        // when
+//        postIdList.forEach(i -> readerPostRepository.addReadPost(memberId, i));
+//
+//        // then
+//        Set<String> postIds = readerPostRepository.findAllReadPostsByMemberId(memberId);
+//        Set<String> expectedList = new HashSet<>(postIdList);
+//        assertThat(expectedList).isEqualTo(postIds);
+//    }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 읽은 게시물 반환 되지 않는 로직 임시 제거

## 🔖 반영 브랜치
- feature/BBB-125 -> dev

## 📷 이미지 첨부

## 🔧 앞으로의 과제

-

## ➕ 이슈 링크

- https://bangbangbwa.atlassian.net/jira/software/projects/BBB/boards/1?selectedIssue=BBB-125
